### PR TITLE
feat(nuxt): 集成 Umami 跟踪并添加相关页面

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,7 +11,7 @@ export default defineNuxtConfig({
 	modules: [
 		// '@nuxtjs/tailwindcss',
 		'@nuxt/eslint',
-		// 'nuxt-umami',
+		'nuxt-umami',
 		'@nuxt/ui',
 		'@clerk/nuxt',
 		'@nuxt/image',
@@ -43,6 +43,19 @@ export default defineNuxtConfig({
 	// 	},
 	// },
 	// },
+	umami: {
+		id: '7e8c67ee-760d-4f16-a4c1-12f9ac0452f4',
+		host: 'https://nuxt-blog.weiibn.shop',
+		autoTrack: true,
+		// proxy: 'cloak',
+		// useDirective: true,
+		// ignoreLocalhost: true,
+		// excludeQueryParams: false,
+		// domains: ['cool-site.app', 'my-space.site'],
+		// customEndpoint: '/my-custom-endpoint',
+		// enabled: false,
+		// logErrors: true,
+	},
 	colorMode: {
 		// 根据系统设置自动切换
 		preference: 'light', // 可选 'light'/'dark'/'system'

--- a/src/pages/umami/index.vue
+++ b/src/pages/umami/index.vue
@@ -1,0 +1,17 @@
+<template>
+	<div>
+		<button @click="umTrackEvent('button-1')">Button 1</button>
+		<button @click="onAction">Button 2</button>
+	</div>
+</template>
+
+<script setup lang="ts">
+function onAction() {
+	umIdentify({ campaign: 'twix-trial' })
+	umTrackEvent('signup', { prop: 123, otherProp: 'anything', isBool: true })
+}
+
+onMounted(() => {
+	umTrackView()
+})
+</script>


### PR DESCRIPTION
- 在 nuxt.config.ts 中启用 nuxt-umami 模块
- 添加 Umami 配置信息
- 新增 umami/index.vue 页面用于测试跟踪功能
- 在测试页面中添加按钮和事件处理函数，用于触发 Umami 事件跟踪