### PR TITLE
docs(README): 更新 ContentRenderer 组件说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,4 @@ NUXT_PUBLIC_ 前缀的变量会暴露给客户端
 
 nuxt-content
 
-<ContentRenderer> 组件用于渲染通过 queryCollection() 查询获得的文档 ，此组件 仅支持Markdown 文件
+`<ContentRenderer>` 组件用于渲染通过 queryCollection() 查询获得的文档 ，此组件 仅支持Markdown 文件

--- a/content.config.ts
+++ b/content.config.ts
@@ -4,7 +4,7 @@ export default defineContentConfig({
 	collections: {
 		posts: defineCollection({
 			type: 'page',
-			source: 'posts/*.md',
+			source: 'posts/*.{md|json|yml}',
 			// schema: z.object({
 			// 	date: z.string(),
 			// }),

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -161,7 +161,7 @@ export default defineNuxtConfig({
 			alias: {},
 		},
 		preview: {
-			api: 'https://api.nuxt.studio',
+			api: 'https://nuxt-blog-studio.nuxt.space/',
 		},
 	},
 	i18n: {


### PR DESCRIPTION
- 修改 README.md 中关于 ContentRenderer 组件的描述，使用反引号包裹组件名称
- 在 content.config.ts 中扩展 posts 集合的源文件类型，支持 md、json 和 yml 文件
- 更新 nuxt.config.ts 中的预览 API 地址