### PR TITLE
refactor(nuxt-config): 优化 umami 域名配置

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,7 +18,7 @@ export default defineNuxtConfig({
 				autoTrack: true,
 				// proxy: 'cloak',
 				useDirective: true,
-				domains: NUXT_PUBLIC_UMAMI_DOMAINS?.split(','),
+				domains: NUXT_PUBLIC_UMAMI_DOMAINS?.split(',') ?? [],
 				ignoreLocalhost: true,
 				// excludeQueryParams: false,
 				// customEndpoint: '/my-custom-endpoint',


### PR DESCRIPTION
- 在 nuxt.config.ts 文件中，更新 umami 配置的 domains 字段
- 使用空数组作为 split 方法的默认值，以避免潜在的运行时错误