### PR TITLE
feat(posts): 优化文章页面布局并添加 Swiper 支持

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -4,7 +4,7 @@ export default defineContentConfig({
 	collections: {
 		posts: defineCollection({
 			type: 'page',
-			source: 'posts/*.{md|json|yml}',
+			source: 'posts/*.md',
 			// schema: z.object({
 			// 	date: z.string(),
 			// }),

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -36,6 +36,7 @@ export default defineNuxtConfig({
 		'@clerk/nuxt',
 		// '@pinia/nuxt',
 		'@nuxt/image',
+		'nuxt-swiper',
 		'@nuxtjs/i18n',
 		'@nuxtjs/color-mode',
 	],
@@ -162,6 +163,7 @@ export default defineNuxtConfig({
 		},
 		preview: {
 			api: 'https://nuxt-blog-studio.nuxt.space',
+			dev: true,
 		},
 	},
 	i18n: {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"normalize.css": "^8.0.1",
 		"nprogress": "^0.2.0",
 		"nuxt": "3.17.5",
+		"nuxt-swiper": "^2.0.1",
 		"nuxt-umami": "^3.2.0",
 		"qss": "^3.0.0",
 		"rehype-autolink-headings": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       nuxt:
         specifier: 3.17.5
         version: 3.17.5(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.0.15)(better-sqlite3@12.2.0)(db0@0.3.2(better-sqlite3@12.2.0))(eslint@9.31.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.45.1)(terser@5.43.1)(typescript@5.8.3)(vite@6.3.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
+      nuxt-swiper:
+        specifier: ^2.0.1
+        version: 2.0.1(magicast@0.3.5)
       nuxt-umami:
         specifier: ^3.2.0
         version: 3.2.0(magicast@0.3.5)
@@ -5288,6 +5291,9 @@ packages:
     resolution: {integrity: sha512-w0ZgRCE9wGZLbmAnCUV2F4/Gjwy1J6L9FejrpTHSHM8Igrf2THwe809QOXbdV8g4+Elkz2MeC/34ZFyt05tKCg==}
     hasBin: true
 
+  nuxt-swiper@2.0.1:
+    resolution: {integrity: sha512-mUAzuGqQHcsqJa1p5y/Hafvurn62o6njHq8DcwQErourkpJpv7z/SnnT0ezXMr7YvDPNg22ayEKGdHkGXXOxMQ==}
+
   nuxt-umami@3.2.0:
     resolution: {integrity: sha512-fqX5tX+2P/5J0fES3C7ykJP6H4bcP8fJzYZP7UcIW0ibwuLRbBzTRDdCd7gEkaXB0nABpSfKlCVInhMcIs07GA==}
 
@@ -6622,6 +6628,10 @@ packages:
     resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
     engines: {node: '>=16'}
     hasBin: true
+
+  swiper@11.2.10:
+    resolution: {integrity: sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==}
+    engines: {node: '>= 4.7.0'}
 
   swr@2.3.4:
     resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
@@ -9102,7 +9112,7 @@ snapshots:
 
   '@nuxt/telemetry@2.6.6(magicast@0.3.5)':
     dependencies:
-      '@nuxt/kit': 3.17.5(magicast@0.3.5)
+      '@nuxt/kit': 3.17.7(magicast@0.3.5)
       citty: 0.1.6
       consola: 3.4.2
       destr: 2.0.5
@@ -13419,6 +13429,13 @@ snapshots:
       - magicast
       - vue-component-type-helpers
 
+  nuxt-swiper@2.0.1(magicast@0.3.5):
+    dependencies:
+      '@nuxt/kit': 3.17.7(magicast@0.3.5)
+      swiper: 11.2.10
+    transitivePeerDependencies:
+      - magicast
+
   nuxt-umami@3.2.0(magicast@0.3.5):
     dependencies:
       '@nuxt/kit': 3.17.7(magicast@0.3.5)
@@ -15073,6 +15090,8 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.4.1
+
+  swiper@11.2.10: {}
 
   swr@2.3.4(react@19.1.0):
     dependencies:

--- a/src/components/footer/Footer.vue
+++ b/src/components/footer/Footer.vue
@@ -35,11 +35,11 @@ if (error.value) {
 }
 
 // 打印调试信息
-console.log('网站数据数组:', data.value)
+// console.log('网站数据数组:', data.value)
 
 // 存储到 Ref
 if (data.value) {
 	umamiState.value = data.value
-	console.log('处理后的数据:', umamiState.value)
+	// console.log('处理后的数据:', umamiState.value)
 }
 </script>

--- a/src/pages/posts/[slug].vue
+++ b/src/pages/posts/[slug].vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="mx-auto max-w-3xl p-4">
+	<div class="flex w-full items-center justify-center">
 		<!-- 渲染Markdown内容 -->
 		<template v-if="posts">
 			<ContentRenderer :value="posts" />
@@ -7,8 +7,8 @@
 		<template v-else>
 			<div class="empty-page">
 				<h1>页面未找到</h1>
-				<p>抱歉！您查找的内容不存在。</p>
-				<NuxtLink to="/">返回首页</NuxtLink>
+				<p class="pb-4">抱歉！您查找的内容不存在</p>
+				<NuxtLink to="/" class="w-full text-center">返回首页</NuxtLink>
 			</div>
 		</template>
 	</div>


### PR DESCRIPTION
- 修改 posts 页面的模板布局，使其更加居中和响应式
- 在项目中集成 nuxt-swiper 模块，支持 Swiper 功能
- 更新 content.config.ts，仅允许 .md 文件作为文章源
- 在 Footer 组件中注释掉调试日志输出